### PR TITLE
Specify correct content_script in manifest

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -15,7 +15,7 @@
   "content_scripts": [
     {
       "matches": ["https://*/*", "http://*/*"],
-      "js": ["popup/bundle.js"]
+      "js": ["main.js"]
     }
   ],
   "background": {


### PR DESCRIPTION
Incorrect content script specified in _manifest.json_, resulting in addon being visible inline with certain websites.